### PR TITLE
Add `sd_product tag` to auto-gen pr. layout

### DIFF
--- a/layouts/auto_generated_product.tpl
+++ b/layouts/auto_generated_product.tpl
@@ -14,6 +14,8 @@
   {% include "edicy-tools-variables" with "product_page" %}
   {% include "html-head" %}
   {% include "edicy-tools-styles" %}
+
+  {% sd_product %}
 </head>
 
 <body class="item-page product-page {% if site.search.enabled %}search-enabled{% endif %}{% if editmode %} editmode{% endif %}">


### PR DESCRIPTION
Include `sd_product` tag in Auto-rendered Product layout to render out product structured data.

Closes #121 